### PR TITLE
fix hardcoded http reference that breaks https websites

### DIFF
--- a/aboutme.php
+++ b/aboutme.php
@@ -75,7 +75,7 @@ class AboutMePlugin extends Plugin
     private function getGravatarUrl()
     {
         $gravatar = $this->config->get('plugins.aboutme.gravatar');
-        $url = 'http://www.gravatar.com/avatar/';
+        $url = '//www.gravatar.com/avatar/';
         $url .= md5(strtolower(trim($gravatar['email'])));
         $url .= '?s=' . $gravatar['size'];
         return $url;


### PR DESCRIPTION
https websites get an error notification that website is serving insecure images from gravatar.com

This removes it and makes it dynamic
