### PR TITLE
Add microformats to the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,4 @@ The simplest way to update this plugin is via the [Grav Package Manager (GPM)](h
 
 This command will check your Grav install to see if your AboutMe plugin is due for an update. If a newer release is found, you will be asked whether or not you wish to update. To continue, type `y` and hit enter. The plugin will automatically update and clear Grav's cache.
 
-
 > Note: Any changes you have made to any of the files listed under this directory will also be removed and replaced by the new set. Any files located elsewhere (for example a YAML settings file placed in `user/config/plugins`) will remain intact.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You can also add links to your social network pages (Twitter, Facebook, GitHub, 
 * Let your visitors know a bit more about yourself, give your name, title/job and a nice description
 * Add links to your social network pages (Including: Twitter, Facebook, Google Plus, GitHub, LinkedIn, Instagram). It uses FontAwesome icons, if your theme already loads it, you don't need to enable the option in the plugin configuration
 * Add other social network pages
+* Add [h-card](http://microformats.org/wiki/h-card) microformats to your homepage to help re-decentralize the Web with the [Indieweb](https://indieweb.org) principles.
 
 # Installation
 

--- a/templates/partials/aboutme.html.twig
+++ b/templates/partials/aboutme.html.twig
@@ -1,19 +1,20 @@
-<div class="about-me">
+<div class="about-me h-card">
 	{% set src = aboutme_picture_src %}
 	{% if not config.plugins.aboutme.gravatar.enabled %}
 		{% set src = uri.rootUrl(false) ~ (uri.rootUrl(false) == '/' ? '' : '/') ~ aboutme_picture_src %}
 	{% endif %}
-	<img src="{{ src }}" title="{{ aboutme_name }}" alt="Profile picture" />
-	<h4>{{ aboutme_name }}</h4>
+	<img src="{{ src }}" title="{{ aboutme_name }}" alt="Profile picture" class="u-photo" />
+	<h4><a href="{{ base_url == '' ? '/' : base_url }}" class="p-name u-url">{{ aboutme_name }}</a></h4>
 	<h3>{{ aboutme_title }}</h3>
-	<p>{{ aboutme_description|nl2br|markdown }}</p>
+	<p class="p-note">{{ aboutme_description|nl2br|markdown }}</p>
 	{% if config.plugins.aboutme.social_pages.enabled %}
 		<div class="social-pages">
 		{% for page in aboutme_pages %}
 			{% if page.url|length %}
-				<a href="{{ page.url }}" {{ page.title ? 'title="' ~ page.title ~ '"' }} target="_blank"><i class="fa fa-2x fa-{{ page.icon }}"></i></a>
+				<a href="{{ page.url }}" {{ page.title ? 'title="' ~ page.title ~ '"' }} target="_blank" rel="me"><i class="fa fa-2x fa-{{ page.icon }}"></i></a>
 			{% endif %}
 		{% endfor %}
 		</div>
 	{% endif %}
 </div>
+

--- a/templates/partials/aboutme.html.twig
+++ b/templates/partials/aboutme.html.twig
@@ -11,7 +11,7 @@
 		<div class="social-pages">
 		{% for page in aboutme_pages %}
 			{% if page.url|length %}
-				<a href="{{ page.url }}" {{ page.title ? 'title="' ~ page.title ~ '"' }} target="_blank" rel="me"><i class="fa fa-2x fa-{{ page.icon }}"></i></a>
+				<a href="{{ page.url }}" {{ page.title ? 'title="' ~ page.title ~ '"' }} target="_blank" rel="me" class="u-url"><i class="fa fa-2x fa-{{ page.icon }}"></i></a>
 			{% endif %}
 		{% endfor %}
 		</div>


### PR DESCRIPTION
This PR adds microformats2 to the template.

microformats2 are the foundation of the modern web, allowing interactions between websites. See [indieweb.org](https://indieweb.org) for more information about the Indieweb.
