### PR TITLE
Replace outer p-tag for description with div

### DIFF
--- a/templates/partials/aboutme.html.twig
+++ b/templates/partials/aboutme.html.twig
@@ -6,7 +6,7 @@
 	<img src="{{ src }}" title="{{ aboutme_name }}" alt="Profile picture" class="u-photo" />
 	<h4><a href="{{ base_url == '' ? '/' : base_url }}" class="p-name u-url">{{ aboutme_name }}</a></h4>
 	<h3>{{ aboutme_title }}</h3>
-	<p class="p-note">{{ aboutme_description|nl2br|markdown|raw }}</p>
+	<div class="p-note">{{ aboutme_description|nl2br|markdown|raw }}</div>
 	{% if config.plugins.aboutme.social_pages.enabled %}
 		<div class="social-pages">
 		{% for page in aboutme_pages %}


### PR DESCRIPTION
The twig template generates a paragraph of text from the description in the configuration that is automatically surrounded by a `<p>` tag. The template also had the `<p class=p-note>` tag. This does not render valid HTML, since nested p-tags are not allowed. This is resolved by replacing the outer tag by a `div` tag.

Because of this, the MF2 parser at https://indiewebify.me/validate-h-card/ does not recognize the note. Replacing by a div-tag fixes this.