### PR TITLE
Change gravatar size field type to number

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -82,11 +82,12 @@ form:
             validate:
                 type: text
         gravatar.size:
-            type: text
+            type: number
             size: small
             label: Size (min 50)
+            default: 100
             validate:
-                type: number
+                type: int
                 min: 50
         Social Pages:
             type: section


### PR DESCRIPTION
A field type of text with mininum values does render working HTML. Instead, `type: number` should be used, with `validate: type: int`.